### PR TITLE
fix: use Mermaid v11 for quadrantChart support

### DIFF
--- a/docs/javascripts/mermaid.mjs
+++ b/docs/javascripts/mermaid.mjs
@@ -1,0 +1,8 @@
+import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+
+mermaid.initialize({
+  startOnLoad: false,
+  securityLevel: "loose",
+});
+
+window.mermaid = mermaid;

--- a/docs/keri-protocol.md
+++ b/docs/keri-protocol.md
@@ -427,11 +427,11 @@ quadrantChart
     quadrant-3 Simple but Limited
     quadrant-4 Decentralized but Limited
     Traditional PKI: [0.10, 0.30]
-    did:web: [0.20, 0.25]
-    did:key: [0.85, 0.10]
-    did:ethr: [0.60, 0.50]
-    did:ion: [0.65, 0.55]
-    did:peer: [0.80, 0.20]
+    did-web: [0.20, 0.25]
+    did-key: [0.85, 0.10]
+    did-ethr: [0.60, 0.50]
+    did-ion: [0.65, 0.55]
+    did-peer: [0.80, 0.20]
     KERI: [0.88, 0.92]
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,8 @@ markdown_extensions:
         - name: mermaid
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
+extra_javascript:
+  - javascripts/mermaid.mjs
 nav:
   - Home: index.md
   - KERI Protocol: keri-protocol.md


### PR DESCRIPTION
## Summary
- Load Mermaid v11 from jsDelivr CDN via custom `docs/javascripts/mermaid.mjs`
- Fixes quadrantChart rendering which is unsupported by mkdocs-material's bundled Mermaid
- Replace colons in chart labels to avoid Mermaid parsing issues