### PR TITLE
feat: add SAID verification on event ingestion

### DIFF
--- a/keri-hs.cabal
+++ b/keri-hs.cabal
@@ -50,6 +50,7 @@ library
     Keri.Crypto.Blake3
     Keri.Crypto.Digest
     Keri.Crypto.Ed25519
+    Keri.Crypto.SAID
     Keri.Event
     Keri.Event.Inception
     Keri.Event.Interaction
@@ -114,6 +115,7 @@ test-suite unit-tests
     Keri.Crypto.Blake3Spec
     Keri.Crypto.DigestSpec
     Keri.Crypto.Ed25519Spec
+    Keri.Crypto.SAIDSpec
     Keri.Event.InceptionSpec
     Keri.Event.InteractionSpec
     Keri.Event.RotationSpec

--- a/lib/Keri/Crypto/SAID.hs
+++ b/lib/Keri/Crypto/SAID.hs
@@ -1,0 +1,68 @@
+module Keri.Crypto.SAID
+    ( verifySaid
+    , replaceDigest
+    ) where
+
+-- \|
+-- Module      : Keri.Crypto.SAID
+-- Description : SAID (Self-Addressing Identifier) verification
+-- Copyright   : (c) 2026 Cardano Foundation
+-- License     : Apache-2.0
+--
+-- Verifies that an event's claimed digest matches the
+-- recomputed SAID. For inception events, both the digest
+-- and prefix must be replaced with the placeholder before
+-- hashing, because 'mkInception' sets @prefix = placeholder@
+-- during SAID computation.
+
+import Keri.Crypto.Digest (computeSaid, saidPlaceholder)
+import Keri.Event
+    ( Event (..)
+    , InceptionData (..)
+    , InteractionData (..)
+    , ReceiptData (..)
+    , RotationData (..)
+    , eventDigest
+    )
+import Keri.Event.Serialize (serializeEvent)
+
+{- | Replace the digest field with the SAID placeholder.
+For inception events, both @d@ and @i@ are replaced
+(because the prefix is derived from the SAID).
+-}
+replaceDigest :: Event -> Event
+replaceDigest = \case
+    Inception InceptionData{..} ->
+        Inception
+            InceptionData
+                { digest = saidPlaceholder
+                , prefix = saidPlaceholder
+                , ..
+                }
+    Rotation RotationData{..} ->
+        Rotation
+            RotationData
+                { digest = saidPlaceholder
+                , ..
+                }
+    Interaction InteractionData{..} ->
+        Interaction
+            InteractionData
+                { digest = saidPlaceholder
+                , ..
+                }
+    Receipt ReceiptData{..} ->
+        Receipt
+            ReceiptData
+                { digest = saidPlaceholder
+                , ..
+                }
+
+{- | Verify that the event's claimed SAID matches the
+recomputed one: replace digest with placeholder, serialize,
+hash, and compare against the original digest field.
+-}
+verifySaid :: Event -> Bool
+verifySaid evt =
+    computeSaid (serializeEvent (replaceDigest evt))
+        == eventDigest evt

--- a/test/spec/Keri/Crypto/SAIDSpec.hs
+++ b/test/spec/Keri/Crypto/SAIDSpec.hs
@@ -1,0 +1,164 @@
+module Keri.Crypto.SAIDSpec (spec) where
+
+import Data.Text (Text)
+import Keri.Cesr.DerivationCode (DerivationCode (..))
+import Keri.Cesr.Encode qualified as Cesr
+import Keri.Cesr.Primitive (Primitive (..))
+import Keri.Crypto.Digest (saidPlaceholder)
+import Keri.Crypto.Ed25519 qualified as Ed
+import Keri.Crypto.SAID (replaceDigest, verifySaid)
+import Keri.Event
+    ( Event (..)
+    , InceptionData (..)
+    , InteractionData (..)
+    , eventDigest
+    , eventPrefix
+    )
+import Keri.Event.Inception
+import Keri.Event.Interaction
+import Keri.Event.Rotation
+import Keri.KeyState.PreRotation (commitKey)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "SAID" $ do
+    describe "verifySaid" $ do
+        it "succeeds for mkInception" $ do
+            evt <- mkTestInception
+            verifySaid evt `shouldBe` True
+
+        it "succeeds for mkInteraction" $ do
+            icp <- mkTestInception
+            let ixn =
+                    mkInteraction
+                        InteractionConfig
+                            { ixPrefix = eventPrefix icp
+                            , ixSequenceNumber = 1
+                            , ixPriorDigest =
+                                eventDigest icp
+                            , ixAnchors = []
+                            }
+            verifySaid ixn `shouldBe` True
+
+        it "succeeds for mkRotation" $ do
+            (icp, nextCesr) <- mkTestInceptionWithNext
+            let rot =
+                    mkRotation
+                        RotationConfig
+                            { rcPrefix = eventPrefix icp
+                            , rcSequenceNumber = 1
+                            , rcPriorDigest =
+                                eventDigest icp
+                            , rcKeys = [nextCesr]
+                            , rcSigningThreshold = 1
+                            , rcNextKeys = []
+                            , rcNextThreshold = 0
+                            , rcConfig = []
+                            , rcAnchors = []
+                            }
+            verifySaid rot `shouldBe` True
+
+        it "fails for tampered signingThreshold" $ do
+            evt <- mkTestInception
+            case evt of
+                Inception InceptionData{..} ->
+                    verifySaid
+                        ( Inception
+                            InceptionData
+                                { signingThreshold = 99
+                                , ..
+                                }
+                        )
+                        `shouldBe` False
+                _ -> expectationFailure "expected inception"
+
+        it "fails for wrong digest field" $ do
+            evt <- mkTestInception
+            case evt of
+                Inception InceptionData{..} ->
+                    verifySaid
+                        ( Inception
+                            InceptionData
+                                { digest = "wrong"
+                                , ..
+                                }
+                        )
+                        `shouldBe` False
+                _ -> expectationFailure "expected inception"
+
+    describe "replaceDigest" $ do
+        it "replaces inception digest + prefix" $ do
+            evt <- mkTestInception
+            case replaceDigest evt of
+                Inception InceptionData{digest, prefix} ->
+                    do
+                        digest `shouldBe` saidPlaceholder
+                        prefix `shouldBe` saidPlaceholder
+                _ -> expectationFailure "expected inception"
+
+        it "replaces interaction digest only" $ do
+            icp <- mkTestInception
+            let ixn =
+                    mkInteraction
+                        InteractionConfig
+                            { ixPrefix = eventPrefix icp
+                            , ixSequenceNumber = 1
+                            , ixPriorDigest =
+                                eventDigest icp
+                            , ixAnchors = []
+                            }
+            case replaceDigest ixn of
+                Interaction
+                    InteractionData{digest, prefix} -> do
+                        digest `shouldBe` saidPlaceholder
+                        prefix
+                            `shouldNotBe` saidPlaceholder
+                _ ->
+                    expectationFailure
+                        "expected interaction"
+
+mkTestInception :: IO Event
+mkTestInception = do
+    kp <- Ed.generateKeyPair
+    nextKp <- Ed.generateKeyPair
+    let pubCesr = encodeKey kp
+        nextPubCesr = encodeKey nextKp
+    nextCommit <-
+        either fail pure $ commitKey nextPubCesr
+    pure $
+        mkInception
+            InceptionConfig
+                { icKeys = [pubCesr]
+                , icSigningThreshold = 1
+                , icNextKeys = [nextCommit]
+                , icNextThreshold = 1
+                , icConfig = []
+                , icAnchors = []
+                }
+
+mkTestInceptionWithNext :: IO (Event, Text)
+mkTestInceptionWithNext = do
+    kp <- Ed.generateKeyPair
+    nextKp <- Ed.generateKeyPair
+    let pubCesr = encodeKey kp
+        nextPubCesr = encodeKey nextKp
+    nextCommit <-
+        either fail pure $ commitKey nextPubCesr
+    let evt =
+            mkInception
+                InceptionConfig
+                    { icKeys = [pubCesr]
+                    , icSigningThreshold = 1
+                    , icNextKeys = [nextCommit]
+                    , icNextThreshold = 1
+                    , icConfig = []
+                    , icAnchors = []
+                    }
+    pure (evt, nextPubCesr)
+
+encodeKey :: Ed.KeyPair -> Text
+encodeKey kp =
+    Cesr.encode $
+        Primitive
+            Ed25519PubKey
+            (Ed.publicKeyBytes (Ed.publicKey kp))


### PR DESCRIPTION
## Summary
- New `Keri.Crypto.SAID` module with `verifySaid` and `replaceDigest`
- SAID check added to `Keri.Kel.Append` before signature verification
- 8 new tests (7 SAID + 1 KEL tampered rejection)

## Test plan
- [ ] `nix develop --quiet -c cabal test unit-tests -O0 --test-show-details=direct` — 95 tests pass